### PR TITLE
Don't call Drupal Scaffold on every install/update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         ]
     },
     "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
@@ -69,12 +68,10 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "@drupal-scaffold",
             "if hash npm; then npm install; fi"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "@drupal-scaffold"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "test": [
             "phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         ]
     },
     "scripts": {
+        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],


### PR DESCRIPTION
**This PR needs testing.**

Drupal scaffold takes a long time to run; it's annoying! In figuring out ways to fix that, I realised that, even when we don't commit the scaffold files to the repository, we still don't need to run it every time. In theory, at least! The documentation says that Drupal scaffold runs automatically whenever Drupal/core is getting installed or updated, which should be enough for our use case, no?