### PR TITLE
Revert "Don't call Drupal Scaffold on every install/update"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,10 +69,12 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "@drupal-scaffold",
             "if hash npm; then npm install; fi"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "@drupal-scaffold"
         ],
         "test": [
             "phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer",


### PR DESCRIPTION
Reverts kalamuna/drupal-project#38

The Drupal Scaffold steps are necessary when deploying from CI to Pantheon. @RobLoach, can you think of a way to make this happen on CircleCI but not on our locals?