### PR TITLE
Bring in latest changes from upstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kalamuna/drupal-project",
-    "description": "Project template for Kalamuna projects with Drupal",
+    "description": "Project template for Kalamuna projects with Drupal via composer.",
     "type": "project",
     "license": "GPL-2.0+",
     "authors": [
@@ -19,17 +19,14 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
-        "drupal/console": "~1.0",
+        "drupal/console": "^1.0.1",
         "drupal/core": "~8.0",
         "drush/drush": "~8.0",
+        "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "drupal/config_installer": "^1.3",
-        "drupal/config_provider": "^1.0",
-        "drupal/config_sync": "1.x-dev",
-        "drupal/config_update": "^1.3",
         "drupal/admin_toolbar": "^1.18",
-        "webflo/drupal-finder": "^0|^1.0.0",
-        "webmozart/path-util": "^2.3"
+        "drupal/stage_file_proxy": "^1.0",
+        "drupal/config_tools": "^1.0"
     },
     "require-dev": {
         "behat/mink": "~1.7",
@@ -39,12 +36,15 @@
         "mikey179/vfsstream": "~1.2",
         "phpunit/phpunit": ">=4.8.28 <5",
         "symfony/css-selector": "~2.8",
+        "geerlingguy/drupal-vm": "^4.2",
         "drupal/browsersync": "^1.0",
         "drupal/twig_xdebug": "^1.0",
         "drupal/devel": "^1.0",
-        "drupal/stage_file_proxy": "^1.0-dev",
-        "geerlingguy/drupal-vm": "^4.2",
-        "drupal/coder": "^8.2"
+        "drupal/coder": "^8.2",
+        "drupal/config_installer": "^1.3",
+        "drupal/config_provider": "^1.0",
+        "drupal/config_sync": "^1.0",
+        "drupal/config_update": "^1.3"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -52,7 +52,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-      "sort-packages": true
+        "sort-packages": true
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Also, a few local changes:
- Moves some dependencies from `require` to `require-dev` and one vice versa.
- Adds a dependency on `config_tools`, which I'd like to adopt going forward in our confg management workflow.