### PR TITLE
Fix Chosen install path to web/libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,18 +37,19 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
-        "drupal/console": "^1.0.1",
-        "drupal/core": "~8.0",
-        "drush/drush": "~8.0",
-        "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3",
         "drupal/admin_toolbar": "^1.18",
         "drupal/cache_control_override": "^1.0",
         "drupal/config_split": "^1.1",
         "drupal/config_tools": "^1.0",
+        "drupal/console": "^1.0.1",
+        "drupal/core": "~8.0",
         "drupal/pathauto": "^1.0",
         "drupal/redirect": "^1.0",
-        "drupal/stage_file_proxy": "^1.0"
+        "drupal/stage_file_proxy": "^1.0",
+        "drush/drush": "~8.0",
+        "oomphinc/composer-installers-extender": "^1.1",
+        "webflo/drupal-finder": "^1.0.0",
+        "webmozart/path-util": "^2.3"
     },
     "require-dev": {
         "behat/mink": "~1.7",
@@ -101,11 +102,12 @@
         ]
     },
     "extra": {
+        "installer-types": ["component"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
             "web/libraries/{$name}": [
                 "type:drupal-library",
-                "components/chosen"
+                "type:component"
             ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/{$name}": ["drupal/config_installer"],

--- a/composer.json
+++ b/composer.json
@@ -31,21 +31,6 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        "chosen": {
-            "type": "package",
-            "package": {
-                "name": "harvesthq/chosen",
-                "version": "1.8.2",
-                "type": "drupal-library",
-                "dist": {
-                    "url": "https://github.com/harvesthq/chosen/releases/download/v1.8.2/chosen_v1.8.2.zip",
-                    "type": "zip"
-                },
-                "require": {
-                    "composer/installers": "^1.2.0"
-                }
-            }
         }
     },
     "require": {
@@ -75,7 +60,7 @@
         "symfony/css-selector": "~2.8",
         "drupal/config_installer": "^1.3",
         "geerlingguy/drupal-vm": "^4.2",
-        "harvesthq/chosen": "^1.0",
+        "components/chosen": "^1.0",
         "kalamuna/kalaconfig": "1.x-dev"
     },
     "conflict": {
@@ -118,7 +103,10 @@
     "extra": {
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library", "type:component"],
+            "web/libraries/{$name}": [
+                "type:drupal-library",
+                "components/chosen"
+            ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/{$name}": ["drupal/config_installer"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],


### PR DESCRIPTION
Makes use of [Composer Installer Extender](https://github.com/oomphinc/composer-installers-extender) to allow installation of arbitrary packages, like those of `component` types.