### PR TITLE
Remove Composer sort-packages and component-dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,10 +71,6 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "config": {
-        "sort-packages": true,
-        "component-dir": "web/libraries"
-    },
     "autoload": {
         "classmap": [
             "scripts/composer/ScriptHandler.php"


### PR DESCRIPTION
This makes two changes...

1. **[`sort-packages`](https://getcomposer.org/doc/06-config.md#sort-packages)** - We want to keep the order of the packages to reduce merge conflicts from the drupal-project upstream. Because of this, remove sort-packages to make it so that when you run `composer require ...`, it doesn't change the order of the packages.
2. **[`component-dir`](https://github.com/RobLoach/component-installer#installation-directory)** - We don't use [component-installer](https://github.com/RobLoach/component-installer), so we don't need to define the config variable for it.

These two config changes will fix the composer configuration.